### PR TITLE
Updated README and added coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: java
+after_success:
+- ./gradlew cobertura coveralls

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Food pantry - Pantry Plus
+[![Build Status](https://travis-ci.org/NAPOSCA/pantryplus.svg?branch=master)](https://travis-ci.org/NAPOSCA/pantryplus)
 [![Coverage Status](https://coveralls.io/repos/github/NAPOSCA/pantryplus/badge.svg?branch=master)](https://coveralls.io/github/NAPOSCA/pantryplus?branch=master)
 
 ## Collaborators

--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
-Food pantry - Pantry Plus
+# Food pantry - Pantry Plus
 
-By:
-- Matt
-- Marc
-- Alex M
-- Jeff
-- Brooke
-- Micheal
+## Collaborators
+- [Matt]
+- [Marc]
+- [Alex]
+- [Jeff]
+- [Brooke]
+- [Micheal]
 
-Where am I?
+## Test our code!
+To run our tests, clone this repo and use `./gradlew test` in bash or command prompt.
+
+[Alex]: https://github.com/alexjamesmalcolm
+[Brooke]: https://github.com/BrookeHau
+[Jeff]: https://github.com/JDSalisbury
+[Micheal]: https://github.com/Xommon
+[Matt]: https://github.com/theoccasionalist
+[Marc]: https://github.com/marcbgold

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Food pantry - Pantry Plus
+[![Coverage Status](https://coveralls.io/repos/github/NAPOSCA/pantryplus/badge.svg?branch=master)](https://coveralls.io/github/NAPOSCA/pantryplus?branch=master)
 
 ## Collaborators
 - [Matt]

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,13 @@ buildscript {
 	}
 }
 
+plugins {
+    id 'net.saliman.cobertura' version '2.3.1'
+    id 'com.github.kt3k.coveralls' version '2.8.2'
+}
+
+cobertura.coverageFormats = ['html', 'xml']
+
 apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'org.springframework.boot'


### PR DESCRIPTION
## README changes:
* Instructions on how to run the tests as was described in the pillar/kata presentation.
* Links to each of our GitHub profiles so we're not just a bunch of names
* Added a badge that shows people that our build is passing to the README
* Added a badge that shows how much of our code is covered by tests

## The addition of Coverage:
* Added Cobertura and coveralls plugins to the build.gradle
* Whenever Travis CI passes a build it reports our coverage to coveralls.io.
### Why
To keep track of how much of our repository is tested and to encourage test driving. It's not a substitute for test driving but a gauge to see how well we're doing.
### How
Every time someone pushes to GitHub, Travis CI tests that build. If that build is successful then Travis CI reports the code coverage to coveralls.io.
### What
https://en.wikipedia.org/wiki/Code_coverage
>  **Test coverage** is a measure used to describe the degree to which the source code of a program is executed when a particular test suite runs. A program with high test coverage, measured as a percentage, has had more of its source code executed during testing, which suggests it has a lower chance of containing undetected software bugs compared to a program with low test coverage.

https://coveralls.io/
> **Coveralls** is a web service to help you track your code coverage over time, and ensure that all your new code is fully covered.