### PR TITLE
added jsonignore annotations to prevent infinite loops

### DIFF
--- a/src/main/java/org/wecancodeit/pantryplus/LineItem.java
+++ b/src/main/java/org/wecancodeit/pantryplus/LineItem.java
@@ -5,6 +5,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 @Entity
 public class LineItem {
 
@@ -12,6 +14,7 @@ public class LineItem {
 	@GeneratedValue
 	private long id;
 
+	@JsonIgnore
 	@ManyToOne
 	private Cart cart;
 

--- a/src/main/java/org/wecancodeit/pantryplus/Product.java
+++ b/src/main/java/org/wecancodeit/pantryplus/Product.java
@@ -8,6 +8,8 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 @Entity
 public class Product {
 
@@ -16,9 +18,11 @@ public class Product {
 	private long id;
 	private String name;
 
+	@JsonIgnore
 	@ManyToOne
 	private Category category;
 
+	@JsonIgnore
 	@OneToMany(mappedBy = "product")
 	private Collection<LineItem> lineItem;
 
@@ -58,11 +62,11 @@ public class Product {
 			return true;
 		}
 
-		if (obj == null ) {
+		if (obj == null) {
 			return false;
 		}
-		
-		if(getClass() != obj.getClass()) {
+
+		if (getClass() != obj.getClass()) {
 			return false;
 		}
 


### PR DESCRIPTION
Product and LineItem now have @JsonIgnore annotations to prevent infinite loops when reading as JSON objects.  Travis should stop taking forever now.  Probably.