### PR TITLE
Fixed linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+src/test/js/lib/**/*.js linguist-vendored
+src/test/js/SpecRunner.html linguist-vendored


### PR DESCRIPTION
Linguist misqualified our project as a primarily JavaScript because jasmine is not vendor-ed. I fixed this in .gitattributes