### PR TITLE
Persist me baby!

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ repositories {
 	mavenCentral()
 }
 
+test {
+	environment "JDBC_DATABASE_URL", "" //I don't know how this empty quote is working but it works just as well as 'jdbc:h2:~/test' for some reason
+}
 
 dependencies {
 	compile('org.springframework.boot:spring-boot-starter-data-jpa')

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 	compile('org.springframework.boot:spring-boot-starter-mail')
 	compile('org.springframework.data:spring-data-rest-hal-browser')
 	runtime('org.springframework.boot:spring-boot-devtools')
-	runtime('com.h2database:h2')
+	runtime('org.postgresql:postgresql')
+	testCompile('com.h2database:h2')
 	testCompile('org.springframework.boot:spring-boot-starter-test')
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+spring.datasource.url=${JDBC_DATABASE_URL}
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
 spring.mail.username=${SPRING_MAIL_USERNAME}


### PR DESCRIPTION
This is the persistent Postgres database that we were talking about last time we met up.

This branch uses the config var provided by Heroku called `JDBC_DATABASE_URL`. This is the url for our production database. The URL is a combination of host, username, password, and port. The username and password are changed a few times a year so I used the Heroku's auto-updating config var instead of hardcoding the database URL. This also works to our advantage that we can change the value of the env var through Gradle in tests and leave it unchanged in production.